### PR TITLE
adds xbox operator that mimics gamepad operator control

### DIFF
--- a/src/main/java/frc/robot/CommandFactory.java
+++ b/src/main/java/frc/robot/CommandFactory.java
@@ -94,6 +94,18 @@ public class CommandFactory {
           }
         return gameMode;
     }
+
+    public void setScoringLevel(String level){
+        levelEntry.setString(level);
+    }
+
+    public void setRobotAlignmentPosition(String alignmentValue){
+        leftRightEntry.setString(alignmentValue);
+    }
+
+    public void setGameMode(String gameMode){
+        gameModeEntry.setString(gameMode);
+    }
     
         //These were test functions. I'd prefer to keep them now so I can reference how I did certain commands later. 
         //I'll eventually delete them

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,6 +5,8 @@
 package frc.robot;
 
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.drive.RobotDriveBase;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.Constants.DriveControlConstants;
 import frc.robot.Constants.SetpointConstants;
@@ -56,9 +58,9 @@ public class RobotContainer {
             DriveControlConstants.DRIVE_DEADBAND)),
         DriveControlConstants.FIELD_ORIENTED_DRIVE));
 
-        coralIntake.setDefaultCommand(coralIntake.setZero());
-        coralWrist.setDefaultCommand(coralWrist.setWristSpeed(0).withName("coral Wrist default"));
-        //elevator.setDefaultCommand(elevator.setSpeedManualControl(0));
+    coralIntake.setDefaultCommand(coralIntake.setZero());
+    coralWrist.setDefaultCommand(coralWrist.setWristSpeed(0).withName("coral Wrist default"));
+    // elevator.setDefaultCommand(elevator.setSpeedManualControl(0));
   }
 
   private void configureButtonBindingsDriver() {
@@ -70,20 +72,20 @@ public class RobotContainer {
   }
 
   private void configureButtonBindingsOperator() {
-    operatorController.rightTrigger()
-        .onTrue(coralWrist.goToSetpointCommand(SetpointConstants.CORAL_INTAKE_ANGLE.in(Radians))
-            .withName("move coral wrist to intake setpoint"));
-    operatorController.rightBumper()
-        .onTrue(coralWrist.goToSetpointCommand(SetpointConstants.CORAL_OUTTAKE_ANGLE.in(Radians))
-            .withName("move coral wrist to outtake setpoint"));
-    operatorController.y().onTrue(elevator.goToGoalSetpointCmd(SetpointConstants.L_TWO_HEIGHT));
-    operatorController.x().onTrue(elevator.goToGoalSetpointCmd(SetpointConstants.L_THREE_HEIGHT));
-    //operatorController.b().whileTrue(elevator.incrementGoalPosition(Meters.of(0.005)));
-    operatorController.b().whileTrue(elevator.setSpeedManualControl(0.1));
-    operatorController.a().whileTrue(elevator.setSpeedManualControl(-0.1));  
-    operatorController.leftBumper().onTrue(elevator.goToGoalSetpointCmd(Meters.of(0.0)));
-    //operatorController.a().whileTrue(elevator.incrementGoalPosition(Meters.of(-0.005)));
-    //operatorController.leftBumper().onTrue(coralWrist.goToSetpointCommand(SetpointConstants.CORAL_L1_ANGLE.in(Radians))
-        //.withName("move coral wrist to L1 outtake setpoint"));
+    // these buttons should not be changed for local testing and should function as
+    // a replacement gamepad
+    operatorController.a().onTrue(Commands.runOnce(() -> commandFactory.setScoringLevel("Level 1")));
+    operatorController.b().onTrue(Commands.runOnce(() -> commandFactory.setScoringLevel("Level 2")));
+    operatorController.x().onTrue(Commands.runOnce(() -> commandFactory.setScoringLevel("Level 3")));
+    operatorController.y().onTrue(Commands.runOnce(() -> commandFactory.setScoringLevel("Level 4")));
+
+    operatorController.rightBumper().onTrue(Commands.runOnce(() -> commandFactory.setRobotAlignmentPosition("right")));
+    operatorController.leftBumper().onTrue(Commands.runOnce(() -> commandFactory.setRobotAlignmentPosition("left")));
+
+    operatorController.rightTrigger().onTrue(Commands.runOnce(() -> commandFactory.setGameMode("coral")));
+    operatorController.leftTrigger().onTrue(Commands.runOnce(() -> commandFactory.setGameMode("algae")));
+
+    // place local buttons below here, delete before PRing
+
   }
 }


### PR DESCRIPTION
This PR clears out all the existing operator control and replaces it with a xbox control that works the same as the gamepad. This will allow testing to closely resemble actual match conditions without requiring the gamepad. It also will help validate that the gamepad will integrate correctly with commands. 