### PR TITLE
switching absolute encoder to relative for coral wrist

### DIFF
--- a/src/main/java/frc/robot/subsystems/coralWrist/CoralWristHardware.java
+++ b/src/main/java/frc/robot/subsystems/coralWrist/CoralWristHardware.java
@@ -127,14 +127,14 @@ public class CoralWristHardware implements CoralWristIO {
     coralIntakeWristClosedLoopController.setReference(desiredAngle.in(Radians), ControlType.kPosition,
         ClosedLoopSlot.kSlot0,
         coralWristFeedFoward.calculate(desiredAngle.in(Radians),
-            coralIntakeWristAbsoluteEncoder.getVelocity()));
+            coralIntakeWristRelativeEncoder.getVelocity()));
     goalAngle = desiredAngle;
   }
 
   @Override
   public void setWristSpeed(double speed) {
     coralIntakeWristSparkFlex.set(speed
-        + coralWristFeedFoward.calculate(coralIntakeWristAbsoluteEncoder.getPosition()
+        + coralWristFeedFoward.calculate(coralIntakeWristRelativeEncoder.getPosition()
             + WRIST_ANGULAR_OFFSET.in(Radians), speed));
   }
 


### PR DESCRIPTION
we changed the absolute encoder to a relative encoder for commands in the coral wrist hardware to try and fix the wrist level. problem = something with the initialization of the encoders.