### PR TITLE
Limit can utilization

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -58,7 +58,8 @@ public final class Constants {
 
   public static class SpeedConstants {
     public static final double MAIN_LOOP_FREQUENCY_HZ = 50;
-    public static final double LOGGING_FREQUENCY_HZ = 10; 
+    public static final double LOGGING_FREQUENCY_HZ = 10;
+    public static final int LOGGING_FREQUENCY_MS = (int) (1000 / LOGGING_FREQUENCY_HZ); 
     public static final AngularVelocity ALGAE_INTAKE_SPEED = MotorConstants.NEO550_FREE_SPEED.times(1);
     public static final AngularVelocity ALGAE_OUTAKE_SPEED = MotorConstants.NEO550_FREE_SPEED.times(-0.50);
     public static final double DRIVETRAIN_MAX_SPEED_MPS = 4.8;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -58,6 +58,7 @@ public final class Constants {
 
   public static class SpeedConstants {
     public static final double MAIN_LOOP_FREQUENCY_HZ = 50;
+    public static final double LOGGING_FREQUENCY_HZ = 10; 
     public static final AngularVelocity ALGAE_INTAKE_SPEED = MotorConstants.NEO550_FREE_SPEED.times(1);
     public static final AngularVelocity ALGAE_OUTAKE_SPEED = MotorConstants.NEO550_FREE_SPEED.times(-0.50);
     public static final double DRIVETRAIN_MAX_SPEED_MPS = 4.8;

--- a/src/main/java/frc/robot/subsystems/algaeIntake/AlgaeIntakeHardware.java
+++ b/src/main/java/frc/robot/subsystems/algaeIntake/AlgaeIntakeHardware.java
@@ -21,6 +21,7 @@ import edu.wpi.first.units.measure.Time;
 import com.revrobotics.spark.config.SparkBaseConfig;
 import com.revrobotics.spark.config.SparkMaxConfig;
 
+import frc.robot.Constants;
 import frc.robot.Constants.MotorConstants;
 import frc.robot.Constants.MotorIdConstants;
 import frc.robot.Constants.SpeedConstants;
@@ -62,6 +63,11 @@ public class AlgaeIntakeHardware implements AlgaeIntakeIO {
                                 .outputRange(ALGAE_MOTOR_MIN_OUTPUT, ALGAE_MOTOR_MAX_OUTPUT)
                                 .positionWrappingEnabled(POSITION_WRAPPING_ENABLED);
 
+                algaeIntakeSparkMaxConfig.signals
+                        .appliedOutputPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS) 
+                        .outputCurrentPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                        .busVoltagePeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS);
+
                 algaeIntakeSparkMax = new SparkMax(MotorIdConstants.ALGAE_BETA_INTAKE_CAN_ID, MotorType.kBrushless);
 
                 algaeIntakeEncoder = algaeIntakeSparkMax.getEncoder();
@@ -70,6 +76,7 @@ public class AlgaeIntakeHardware implements AlgaeIntakeIO {
                                 PersistMode.kPersistParameters);
 
                 algaeIntakeClosedLoopController = algaeIntakeSparkMax.getClosedLoopController();
+
         }
 
         public void setRollerSpeed(AngularVelocity speed) {

--- a/src/main/java/frc/robot/subsystems/algaeWrist/AlgaeWristHardware.java
+++ b/src/main/java/frc/robot/subsystems/algaeWrist/AlgaeWristHardware.java
@@ -21,6 +21,7 @@ import com.revrobotics.spark.config.SparkFlexConfig;
 
 import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.units.measure.Angle;
+import frc.robot.Constants;
 import frc.robot.CommandFactory.Setpoint;
 import frc.robot.Constants.MotorConstants;
 import frc.robot.Constants.MotorIdConstants;
@@ -90,6 +91,11 @@ public class AlgaeWristHardware implements AlgaeWristIO {
                                 .forwardSoftLimitEnabled(SOFT_LIMIT_ENABLED)
                                 .reverseSoftLimit(REVERSE_SOFT_LIMIT.in(Radians))
                                 .reverseSoftLimitEnabled(SOFT_LIMIT_ENABLED);
+                
+                wristSparkMaxConfig.signals
+                                .appliedOutputPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                                .busVoltagePeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                                .outputCurrentPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS);
 
                 algaeWristSparkMax = new SparkFlex(MotorIdConstants.ALGAE_BETA_WRIST_CAN_ID, MotorType.kBrushless);
 

--- a/src/main/java/frc/robot/subsystems/coralIntake/CoralIntakeAlphaHardware.java
+++ b/src/main/java/frc/robot/subsystems/coralIntake/CoralIntakeAlphaHardware.java
@@ -21,6 +21,7 @@ import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.Seconds;
 
+import frc.robot.Constants;
 import frc.robot.Constants.MotorConstants;
 import frc.robot.Constants.MotorIdConstants;
 import frc.robot.Constants.SpeedConstants;
@@ -68,6 +69,11 @@ public class CoralIntakeAlphaHardware implements CoralIntakeIO {
                                 .outputRange(INTAKE_MOTOR_MIN_OUTPUT, INTAKE_MOTOR_MAX_OUTPUT)
                                 .positionWrappingEnabled(POSITION_WRAPPING_ENABLED_SIDE_MOTORS);
 
+                leftSparkMaxConfig.signals
+                                .appliedOutputPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                                .busVoltagePeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                                .outputCurrentPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS);
+
                 rightSparkMaxConfig.inverted(RIGHT_MOTOR_INVERTED).idleMode(IDLE_MODE)
                                 .smartCurrentLimit((int) MotorConstants.NEO550_CURRENT_LIMIT.in(Amps));
                 rightSparkMaxConfig.encoder.positionConversionFactor(ENCODER_ROLLER_POSITION_FACTOR)
@@ -75,6 +81,11 @@ public class CoralIntakeAlphaHardware implements CoralIntakeIO {
                 rightSparkMaxConfig.closedLoop.feedbackSensor(FeedbackSensor.kPrimaryEncoder)
                                 .pidf(INTAKE_MOTOR_P, INTAKE_MOTOR_I, INTAKE_MOTOR_D, INTAKE_MOTOR_FF)
                                 .outputRange(INTAKE_MOTOR_MIN_OUTPUT, INTAKE_MOTOR_MAX_OUTPUT);
+
+                rightSparkMaxConfig.signals
+                                .appliedOutputPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                                .busVoltagePeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                                .outputCurrentPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS);
 
                 coralIntakeLeftSparkMax = new SparkMax(MotorIdConstants.CORAL_ALPHA_INTAKE_LEFT_CAN_ID, MotorType.kBrushless);
                 coralIntakeRightSparkMax = new SparkMax(MotorIdConstants.CORAL_ALPHA_INTAKE_RIGHT_CAN_ID,

--- a/src/main/java/frc/robot/subsystems/coralIntake/CoralIntakeBetaHardware.java
+++ b/src/main/java/frc/robot/subsystems/coralIntake/CoralIntakeBetaHardware.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.coralIntake;
 
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 
+import frc.robot.Constants;
 import frc.robot.Constants.MotorConstants;
 import frc.robot.Constants.MotorIdConstants;
 import frc.robot.Constants.SpeedConstants;

--- a/src/main/java/frc/robot/subsystems/coralIntake/CoralIntakeBetaHardware.java
+++ b/src/main/java/frc/robot/subsystems/coralIntake/CoralIntakeBetaHardware.java
@@ -67,6 +67,12 @@ public class CoralIntakeBetaHardware implements CoralIntakeIO {
                 .pidf(BETA_CORAL_INTAKE_P, BETA_CORAL_INTAKE_I, BETA_CORAL_INTAKE_D, BETA_CORAL_INTAKE_FF)
                 .outputRange(BETA_CORAL_INTAKE_PID_MIN_OUTPUT, BETA_CORAL_INTAKE_PID_MAX_OUTPUT)
                 .positionWrappingEnabled(BETA_CORAL_INTAKE_POSITION_WRAPPING_ENABLED);
+        
+        betaCoralIntakeConfig.signals
+                .appliedOutputPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                .busVoltagePeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                .outputCurrentPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS);
+
 
         betaCoralIntakeSparkFlex = new SparkFlex(MotorIdConstants.CORAL_BETA_INTAKE_CAN_ID,
                 MotorType.kBrushless);

--- a/src/main/java/frc/robot/subsystems/coralWrist/CoralWristHardware.java
+++ b/src/main/java/frc/robot/subsystems/coralWrist/CoralWristHardware.java
@@ -19,6 +19,7 @@ import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.CommandFactory.Setpoint;
+import frc.robot.Constants;
 import frc.robot.Constants.MotorConstants;
 import frc.robot.Constants.SetpointConstants;
 
@@ -100,6 +101,12 @@ public class CoralWristHardware implements CoralWristIO {
         .forwardSoftLimitEnabled(SOFT_LIMIT_ENABLED)
         .reverseSoftLimit(REVERSE_SOFT_LIMIT.in(Radians))
         .reverseSoftLimitEnabled(SOFT_LIMIT_ENABLED);
+      
+      
+    wristSparkFlexConfig.signals
+                .appliedOutputPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                .busVoltagePeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                .outputCurrentPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS);
 
     coralIntakeWristSparkFlex = new SparkFlex(CAN_ID, MotorType.kBrushless);
     coralIntakeWristAbsoluteEncoder = coralIntakeWristSparkFlex.getAbsoluteEncoder();

--- a/src/main/java/frc/robot/subsystems/elevator/AlphaElevatorHardware.java
+++ b/src/main/java/frc/robot/subsystems/elevator/AlphaElevatorHardware.java
@@ -1,5 +1,12 @@
 package frc.robot.subsystems.elevator;
 
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Volts;
+
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.ClosedLoopSlot;
 import com.revrobotics.spark.SparkBase.ControlType;
@@ -15,18 +22,13 @@ import com.revrobotics.spark.config.SparkFlexConfig;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.State;
-import static edu.wpi.first.units.Units.*;
-
-import java.util.function.Supplier;
-
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Voltage;
-import frc.robot.CommandFactory.Setpoint;
+import frc.robot.Constants;
 import frc.robot.Constants.MotorConstants;
 import frc.robot.Constants.MotorIdConstants;
-import frc.robot.Constants.SetpointConstants;
 
 public class AlphaElevatorHardware implements ElevatorIO {
 
@@ -100,6 +102,11 @@ public class AlphaElevatorHardware implements ElevatorIO {
                 .forwardSoftLimitEnabled(true)
                 .reverseSoftLimit(0)
                 .reverseSoftLimitEnabled(true);
+
+        globalMotorConfig.signals
+                .appliedOutputPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                .busVoltagePeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS)
+                .outputCurrentPeriodMs(Constants.SpeedConstants.LOGGING_FREQUENCY_MS);
 
         leftMotorConfigLeader
                 .apply(globalMotorConfig)

--- a/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
+++ b/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
@@ -122,7 +122,7 @@ public class KrakenElevatorHardware implements ElevatorIO {
         //elevatorLeftMotorLeader.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorLeftMotorLeader.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorLeftMotorLeader.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
-        //elevatorLeftMotorLeader.optimizeBusUtilization();
+        elevatorLeftMotorLeader.optimizeBusUtilization();
         SmartDashboard.putNumber("Elevator/position update frequency", elevatorLeftMotorLeader.getPosition().getAppliedUpdateFrequency());
         SmartDashboard.putNumber("Elevator/velocity update frequency", elevatorLeftMotorLeader.getVelocity().getAppliedUpdateFrequency());
         SmartDashboard.putNumber("Elevator/closed loop output update frequency", elevatorLeftMotorLeader.getClosedLoopOutput().getAppliedUpdateFrequency());
@@ -134,7 +134,7 @@ public class KrakenElevatorHardware implements ElevatorIO {
         //elevatorRightMotorFollower.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorRightMotorFollower.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorRightMotorFollower.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
-        //elevatorRightMotorFollower.optimizeBusUtilization();
+        elevatorRightMotorFollower.optimizeBusUtilization();
 
     }
 

--- a/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
+++ b/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
@@ -116,17 +116,17 @@ public class KrakenElevatorHardware implements ElevatorIO {
         closedLoopController = new PositionVoltage(0).withSlot(0);
 
         //limiting kraken utilization
-        elevatorLeftMotorLeader.optimizeBusUtilization();
-        elevatorLeftMotorLeader.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorLeftMotorLeader.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorLeftMotorLeader.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorLeftMotorLeader.optimizeBusUtilization();
+        //elevatorLeftMotorLeader.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorLeftMotorLeader.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorLeftMotorLeader.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         elevatorLeftMotorLeader.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         elevatorLeftMotorLeader.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
 
-        elevatorRightMotorFollower.optimizeBusUtilization();
-        elevatorRightMotorFollower.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorRightMotorFollower.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorRightMotorFollower.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorRightMotorFollower.optimizeBusUtilization();
+        //elevatorRightMotorFollower.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorRightMotorFollower.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorRightMotorFollower.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         elevatorRightMotorFollower.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         elevatorRightMotorFollower.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
 

--- a/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
+++ b/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
@@ -115,25 +115,6 @@ public class KrakenElevatorHardware implements ElevatorIO {
         elevatorRightMotorFollower.setNeutralMode(NeutralModeValue.Brake);
 
         closedLoopController = new PositionVoltage(0).withSlot(0);
-
-        //limiting kraken utilization
-        //elevatorLeftMotorLeader.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorLeftMotorLeader.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorLeftMotorLeader.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorLeftMotorLeader.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorLeftMotorLeader.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
-        SmartDashboard.putNumber("Elevator/position update frequency", elevatorLeftMotorLeader.getPosition().getAppliedUpdateFrequency());
-        SmartDashboard.putNumber("Elevator/velocity update frequency", elevatorLeftMotorLeader.getVelocity().getAppliedUpdateFrequency());
-        SmartDashboard.putNumber("Elevator/closed loop output update frequency", elevatorLeftMotorLeader.getClosedLoopOutput().getAppliedUpdateFrequency());
-        SmartDashboard.putNumber("Elevator/supply voltage update frequency", elevatorLeftMotorLeader.getSupplyVoltage().getAppliedUpdateFrequency());
-        SmartDashboard.putNumber("Elevator/supply current update frequency", elevatorLeftMotorLeader.getSupplyCurrent().getAppliedUpdateFrequency());
-
-        //elevatorRightMotorFollower.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorRightMotorFollower.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorRightMotorFollower.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorRightMotorFollower.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        //elevatorRightMotorFollower.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
-
     }
 
     public void resetSetpointsToCurrentPosition() {

--- a/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
+++ b/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
@@ -122,7 +122,6 @@ public class KrakenElevatorHardware implements ElevatorIO {
         //elevatorLeftMotorLeader.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorLeftMotorLeader.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorLeftMotorLeader.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
-        elevatorLeftMotorLeader.optimizeBusUtilization();
         SmartDashboard.putNumber("Elevator/position update frequency", elevatorLeftMotorLeader.getPosition().getAppliedUpdateFrequency());
         SmartDashboard.putNumber("Elevator/velocity update frequency", elevatorLeftMotorLeader.getVelocity().getAppliedUpdateFrequency());
         SmartDashboard.putNumber("Elevator/closed loop output update frequency", elevatorLeftMotorLeader.getClosedLoopOutput().getAppliedUpdateFrequency());
@@ -134,7 +133,6 @@ public class KrakenElevatorHardware implements ElevatorIO {
         //elevatorRightMotorFollower.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorRightMotorFollower.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorRightMotorFollower.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
-        elevatorRightMotorFollower.optimizeBusUtilization();
 
     }
 

--- a/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
+++ b/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
@@ -28,6 +28,7 @@ import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Voltage;
 import frc.robot.CommandFactory.Setpoint;
+import frc.robot.Constants;
 import frc.robot.Constants.MotorIdConstants;
 import frc.robot.Constants.SetpointConstants;
 
@@ -113,6 +114,22 @@ public class KrakenElevatorHardware implements ElevatorIO {
         elevatorRightMotorFollower.setNeutralMode(NeutralModeValue.Brake);
 
         closedLoopController = new PositionVoltage(0).withSlot(0);
+
+        //limiting kraken utilization
+        elevatorLeftMotorLeader.optimizeBusUtilization();
+        elevatorLeftMotorLeader.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorLeftMotorLeader.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorLeftMotorLeader.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorLeftMotorLeader.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorLeftMotorLeader.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
+
+        elevatorRightMotorFollower.optimizeBusUtilization();
+        elevatorRightMotorFollower.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorRightMotorFollower.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorRightMotorFollower.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorRightMotorFollower.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        elevatorRightMotorFollower.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
+
     }
 
     public void resetSetpointsToCurrentPosition() {

--- a/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
+++ b/src/main/java/frc/robot/subsystems/elevator/KrakenElevatorHardware.java
@@ -27,6 +27,7 @@ import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.CommandFactory.Setpoint;
 import frc.robot.Constants;
 import frc.robot.Constants.MotorIdConstants;
@@ -116,19 +117,24 @@ public class KrakenElevatorHardware implements ElevatorIO {
         closedLoopController = new PositionVoltage(0).withSlot(0);
 
         //limiting kraken utilization
-        //elevatorLeftMotorLeader.optimizeBusUtilization();
         //elevatorLeftMotorLeader.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorLeftMotorLeader.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorLeftMotorLeader.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorLeftMotorLeader.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorLeftMotorLeader.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
+        //elevatorLeftMotorLeader.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorLeftMotorLeader.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
+        //elevatorLeftMotorLeader.optimizeBusUtilization();
+        SmartDashboard.putNumber("Elevator/position update frequency", elevatorLeftMotorLeader.getPosition().getAppliedUpdateFrequency());
+        SmartDashboard.putNumber("Elevator/velocity update frequency", elevatorLeftMotorLeader.getVelocity().getAppliedUpdateFrequency());
+        SmartDashboard.putNumber("Elevator/closed loop output update frequency", elevatorLeftMotorLeader.getClosedLoopOutput().getAppliedUpdateFrequency());
+        SmartDashboard.putNumber("Elevator/supply voltage update frequency", elevatorLeftMotorLeader.getSupplyVoltage().getAppliedUpdateFrequency());
+        SmartDashboard.putNumber("Elevator/supply current update frequency", elevatorLeftMotorLeader.getSupplyCurrent().getAppliedUpdateFrequency());
 
-        //elevatorRightMotorFollower.optimizeBusUtilization();
         //elevatorRightMotorFollower.getPosition().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorRightMotorFollower.getVelocity().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
         //elevatorRightMotorFollower.getClosedLoopOutput().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorRightMotorFollower.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
-        elevatorRightMotorFollower.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
+        //elevatorRightMotorFollower.getSupplyVoltage().setUpdateFrequency(Constants.SpeedConstants.MAIN_LOOP_FREQUENCY_HZ);
+        //elevatorRightMotorFollower.getSupplyCurrent().setUpdateFrequency(Constants.SpeedConstants.LOGGING_FREQUENCY_HZ);
+        //elevatorRightMotorFollower.optimizeBusUtilization();
 
     }
 


### PR DESCRIPTION
added code to limit can utilization. decided not to limit kraken utilization since most of the kraken values already update at the lowest possible frequency. The current CAN utilization is around 40-45%